### PR TITLE
Fix syntax for postgres 9 (Fixes #18)

### DIFF
--- a/gen-triggers.py
+++ b/gen-triggers.py
@@ -9,7 +9,7 @@ BEGIN
     FOR r IN SELECT routine_schema, routine_name FROM information_schema.routines
              WHERE routine_name LIKE 'notify_skor%'
     LOOP
-        EXECUTE 'DROP FUNCTION ' || quote_ident(r.routine_schema) || '.' || quote_ident(r.routine_name) || ' CASCADE';
+        EXECUTE 'DROP FUNCTION ' || quote_ident(r.routine_schema) || '.' || quote_ident(r.routine_name) || '() CASCADE';
     END LOOP;
 END$$;
 """


### PR DESCRIPTION
After some investigation of #18 It turns out that Postgres 9 requires the parenthesis when calling DROP FUNCTION

```
DROP FUNCTION [ IF EXISTS ] name ( [ [ argmode ] [ argname ] argtype [, ...] ] )
    [ CASCADE | RESTRICT ]
```
https://www.postgresql.org/docs/9.6/static/sql-dropfunction.html

Have tested this against Postgres 9.6 and 10.4 and appears to be functioning correctly on both